### PR TITLE
fix(plugin): handle no git-timestamp on page meta

### DIFF
--- a/mkdocs_blogging_plugin/plugin.py
+++ b/mkdocs_blogging_plugin/plugin.py
@@ -265,10 +265,13 @@ class BloggingPlugin(BasePlugin):
             self.template_file = root_url / self.config.get("template")
 
     def generate_html(self, pages) -> str:
-        blog_pages = sorted(pages,
-                            key=lambda page: page.meta["git-timestamp"],
-                            reverse=self.sort["from"] == "new"
-                            )
+        blog_pages = sorted(
+            pages,
+            key=lambda page: page.meta["git-timestamp"]
+            if "git-timestamp" in page.meta
+            else page,
+            reverse=self.sort["from"] == "new",
+        )
         theme_options = self.theme.get("options") if self.theme else []
         return self.template.render(
             pages=blog_pages, page_size=self.size,
@@ -279,6 +282,10 @@ class BloggingPlugin(BasePlugin):
 
     def sorted_pages(self, pages):
         # print(pages[0].__dict__)
-        return sorted(pages,
-                      key=lambda page: page.meta["git-timestamp"],
-                      reverse=self.sort["from"] == "new")
+        return sorted(
+            pages,
+            key=lambda page: page.meta["git-timestamp"]
+            if "git-timestamp" in page.meta
+            else page,
+            reverse=self.sort["from"] == "new",
+        )

--- a/mkdocs_blogging_plugin/plugin.py
+++ b/mkdocs_blogging_plugin/plugin.py
@@ -267,9 +267,7 @@ class BloggingPlugin(BasePlugin):
     def generate_html(self, pages) -> str:
         blog_pages = sorted(
             pages,
-            key=lambda page: page.meta["git-timestamp"]
-            if "git-timestamp" in page.meta
-            else page,
+            key=lambda page: page.meta.get("git-timestamp"),
             reverse=self.sort["from"] == "new",
         )
         theme_options = self.theme.get("options") if self.theme else []
@@ -284,7 +282,7 @@ class BloggingPlugin(BasePlugin):
         # print(pages[0].__dict__)
         return sorted(
             pages,
-            key=lambda page: page.meta["git-timestamp"]
+            key=lambda page: page.meta.get("git-timestamp")
             if "git-timestamp" in page.meta
             else page,
             reverse=self.sort["from"] == "new",

--- a/mkdocs_blogging_plugin/plugin.py
+++ b/mkdocs_blogging_plugin/plugin.py
@@ -217,8 +217,11 @@ class BloggingPlugin(BasePlugin):
                             page.meta["date"], self.meta_time_format).timestamp()
                 if not timestamp:
                     timestamp = self.util.get_git_commit_timestamp(
-                        page.file.abs_src_path, is_first_commit=self.sort["by"] != "revision")
-                page.meta["git-timestamp"] = timestamp
+                        page.file.abs_src_path,
+                        is_first_commit=self.sort["by"] != "revision",
+                    )
+                if "git-timestamp" in page.meta:
+                    page.meta["git-timestamp"] = timestamp
                 page.meta["localized-time"] = self.util.get_localized_date(
                     timestamp, False, format=self.time_format, _locale=self.locale)
                 self.blog_pages.append(page)

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+from unittest import mock
+
+import pytest
+
+from mkdocs_blogging_plugin import plugin
+
+
+def test_sorted_pages_mock():
+    obj = plugin.BloggingPlugin()
+    with pytest.raises(KeyError):
+        obj.sorted_pages([mock.MagicMock()])
+
+
+def test_sorted_pages_with_sort():
+    obj = plugin.BloggingPlugin()
+    obj.sort = {"from": ""}
+    obj.sorted_pages([mock.MagicMock()])
+
+
+def test_sorted_pages_empty_page_meta():
+    obj = plugin.BloggingPlugin()
+    obj.sort = {"from": ""}
+    page = mock.MagicMock()
+    page.meta = {}
+    obj.sorted_pages([page])


### PR DESCRIPTION
## Proposed changes

when i write drafted text and run `mkdocs serve` mkdocs will raise error that page.meta don't have 'git-timestamp'

first it happened here https://github.com/liang2kl/mkdocs-blogging-plugin/blob/47bff7e969b6f8b7f6e1b8e3e24bff819c8cad09/mkdocs_blogging_plugin/plugin.py#L221

(sorry forget the traceback for this one)

after af8b50acb02483dc244425537bce260aa140a5a8 there is also error on other place for example

```python
> poetry run mkdocs serve
INFO     -  Building documentation...
INFO     -  Cleaning site directory
ERROR    -  Error building page 'index.md': 'git-timestamp'
Traceback (most recent call last):
  File "/home/r3r/.cache/pypoetry/virtualenvs/private-xkr2mhDC-py3.10/bin/mkdocs", line 8, in <module>
    sys.exit(cli())
  File "/home/r3r/.cache/pypoetry/virtualenvs/private-xkr2mhDC-py3.10/lib/python3.10/site-packages/click/core.py", line 1128, in __call__
    return self.main(*args, **kwargs)
  File "/home/r3r/.cache/pypoetry/virtualenvs/private-xkr2mhDC-py3.10/lib/python3.10/site-packages/click/core.py", line 1053, in main
    rv = self.invoke(ctx)
  File "/home/r3r/.cache/pypoetry/virtualenvs/private-xkr2mhDC-py3.10/lib/python3.10/site-packages/click/core.py", line 1659, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/r3r/.cache/pypoetry/virtualenvs/private-xkr2mhDC-py3.10/lib/python3.10/site-packages/click/core.py", line 1395, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/r3r/.cache/pypoetry/virtualenvs/private-xkr2mhDC-py3.10/lib/python3.10/site-packages/click/core.py", line 754, in invoke
    return __callback(*args, **kwargs)
  File "/home/r3r/.cache/pypoetry/virtualenvs/private-xkr2mhDC-py3.10/lib/python3.10/site-packages/mkdocs/__main__.py", line 177, in serve_command
    serve.serve(dev_addr=dev_addr, livereload=livereload, **kwargs)
  File "/home/r3r/.cache/pypoetry/virtualenvs/private-xkr2mhDC-py3.10/lib/python3.10/site-packages/mkdocs/commands/serve.py", line 54, in serve
    config = builder()
  File "/home/r3r/.cache/pypoetry/virtualenvs/private-xkr2mhDC-py3.10/lib/python3.10/site-packages/mkdocs/commands/serve.py", line 49, in builder
    build(config, live_server=live_server, dirty=dirty)
  File "/home/r3r/.cache/pypoetry/virtualenvs/private-xkr2mhDC-py3.10/lib/python3.10/site-packages/mkdocs/commands/build.py", line 314, in build
    _build_page(file.page, config, doc_files, nav, env, dirty)
  File "/home/r3r/.cache/pypoetry/virtualenvs/private-xkr2mhDC-py3.10/lib/python3.10/site-packages/mkdocs/commands/build.py", line 220, in _build_page
    output = config['plugins'].run_event(
  File "/home/r3r/.cache/pypoetry/virtualenvs/private-xkr2mhDC-py3.10/lib/python3.10/site-packages/mkdocs/plugins.py", line 102, in run_event
    result = method(item, **kwargs)
  File "/home/r3r/.cache/pypoetry/virtualenvs/private-xkr2mhDC-py3.10/lib/python3.10/site-packages/mkdocs_blogging_plugin/plugin.py", line 249, in on_post_page
    sorted_entries = {tag: self.sorted_pages(
  File "/home/r3r/.cache/pypoetry/virtualenvs/private-xkr2mhDC-py3.10/lib/python3.10/site-packages/mkdocs_blogging_plugin/plugin.py", line 249, in <dictcomp>
    sorted_entries = {tag: self.sorted_pages(
  File "/home/r3r/.cache/pypoetry/virtualenvs/private-xkr2mhDC-py3.10/lib/python3.10/site-packages/mkdocs_blogging_plugin/plugin.py", line 279, in sorted_pages
    return sorted(pages,
  File "/home/r3r/.cache/pypoetry/virtualenvs/private-xkr2mhDC-py3.10/lib/python3.10/site-packages/mkdocs_blogging_plugin/plugin.py", line 280, in <lambda>
    key=lambda page: page.meta["git-timestamp"],
KeyError: 'git-timestamp'
```
so i write function to replace lambda where page is sorted by git-timestamp

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have added tests that prove my fix is effective or that my feature works

## Further comments

- file is formatted using darker and isort
- there is pytest test but i don't add pytest to setup
- if there is no git-timestamp order by url first then title. there is no reason for this order

---
unrelated but there is also this warning when running pytest
```python
../../../../home/r3r/.cache/pypoetry/virtualenvs/mkdocs-blogging-plugin-6qHKpuQG-py3.10/lib/python3.10/site-packages/mkdocs/utils/filters.py:14
  /home/r3r/.cache/pypoetry/virtualenvs/mkdocs-blogging-plugin-6qHKpuQG-py3.10/lib/python3.10/site-packages/mkdocs/utils/filters.py:14: DeprecationWarning: 'contextfilter' is renamed to 'pass_context', the old name will be removed in Jinja 3.1.
    def url_filter(context, value):

-- Docs: https://docs.pytest.org/en/stable/warnings.html
```
i will create another pr for this later

---

this pr is based from this template https://github.com/appium/appium/blob/master/.github/PULL_REQUEST_TEMPLATE.md