### PR TITLE
feat: add support for configuring blogging with root folder & .pages

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -140,7 +140,7 @@ To generate a blog page for a named category (in our case, `review`):
 ### Category-specific Settings
 
 You can specify the included directories for each category
-and configure the options seperately. The *category-specific* settings include:
+and configure the options separately. The *category-specific* settings include:
 
 ```yaml title="category settings"
 dirs:              # The directories included in the category
@@ -178,19 +178,21 @@ plugins:
           ...
 ```
 
-You can also define the category-specific settings in a YAML file. To do that, you need to add a new default key `config_filename` in the plugin configuration:
+Of all options mentioned above, these deserve special attention:
 
-```yaml title="mkdocs.yml"
-plugins:
-  - blogging:
-      config_filename: .pages
-```
+1. If you have a lots of categories, you might want to put their configuration in a separate YAML file. To do that, you need to add a new default key `config_filename` in the plugin configuration:
 
+    ```yaml title="mkdocs.yml"
+    plugins:
+      - blogging:
+          config_filename: .pages
+    ```
+   Each category must have their own configuration file. For example, if you have a folder named `review`, you need to create a file named `.pages` in it (like : `review/.pages`). This will "transform" the folder into a category.
 
-!!! notes "Awesome pages"
-    You can use the same file as the [awesome pages plugin](https://github.com/lukasgeiter/mkdocs-awesome-pages-plugin).
+    !!! notes "Awesome pages"
+        You can use the same file as the [awesome pages plugin](https://github.com/lukasgeiter/mkdocs-awesome-pages-plugin).
 
-Moreover, you can also automatically create blog pages for each root directory. Theses pages will be named after the directory name. To do that, you need to add or set the key `use_root_dirs` to `true` in the plugin configuration.
+2. You can also automatically create blog pages for each root directory. These pages will be named after the directory name. To do that, you need to add or set the key `use_root_dirs` to `true` in the plugin configuration.
 
 
 For more about themes and custom templates, see [Themes](theme.md) and [Template](template.md) respectively.
@@ -227,6 +229,9 @@ See [the list of datetime placeholders](https://docs.python.org/3/library/dateti
 - `exclude_index` in *global settings* is used to exclude the index page from the blog collection. This is useful when you want to use the index page as a landing page for your blog.
 - `use_root_dirs` in *global settings* is used to automatically create blog pages for each root directory. Theses pages will be named after the directory name.
 - `config_filename` in *global settings* is used to define the filename of the configuration file. See the [category specific options](#category-specific-settings) section for more details.
+
+
+Note that specify a category with the same name as the one from the root directories will override it.
 
 ## Publish with Github Pages
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -178,6 +178,21 @@ plugins:
           ...
 ```
 
+You can also define the category-specific settings in a YAML file. To do that, you need to add a new default key `config_filename` in the plugin configuration:
+
+```yaml title="mkdocs.yml"
+plugins:
+  - blogging:
+      config_filename: .pages
+```
+
+
+!!! notes "Awesome pages"
+    You can use the same file as the [awesome pages plugin](https://github.com/lukasgeiter/mkdocs-awesome-pages-plugin).
+
+Moreover, you can also automatically create blog pages for each root directory. Theses pages will be named after the directory name. To do that, you need to add or set the key `use_root_dirs` to `true` in the plugin configuration.
+
+
 For more about themes and custom templates, see [Themes](theme.md) and [Template](template.md) respectively.
 
 ### Global Settings
@@ -192,6 +207,9 @@ features:          # Additional features
 locale: en         # The locale for time localizations, default: system's locale
 time_format: '%Y-%m-%d %H:%M:%S' # The format used to display the time
 meta_time_format: '%Y-%m-%d %H:%M:%S' # The format used to parse the time from meta
+exclude_index: false # Exclude the index page from the blog collection (default: false)
+use_root_dirs: false # Automatically create blog pages for each root directory (default: false)
+config_filename: .pages # The filename of the configuration file (default: none)
 ```
 
 Of all the options mentioned above, these deserve special attention:
@@ -206,6 +224,9 @@ See [the list of datetime placeholders](https://docs.python.org/3/library/dateti
 
 - When `paging` in *category settings* is set to `false`, if `size` is not set, all posts will be displayed on the first page; otherwise the first
 `size` posts will be displayed and *the rest will not*.
+- `exclude_index` in *global settings* is used to exclude the index page from the blog collection. This is useful when you want to use the index page as a landing page for your blog.
+- `use_root_dirs` in *global settings* is used to automatically create blog pages for each root directory. Theses pages will be named after the directory name.
+- `config_filename` in *global settings* is used to define the filename of the configuration file. See the [category specific options](#category-specific-settings) section for more details.
 
 ## Publish with Github Pages
 

--- a/mkdocs_blogging_plugin/config.py
+++ b/mkdocs_blogging_plugin/config.py
@@ -15,5 +15,5 @@ class BloggingConfig:
         self.paging = config.get("paging", True)
         self.show_total = config.get("show_total", True)
         self.template = config.get("template")
-        self.theme = config.get("theme")    
+        self.theme = config.get("theme")
         self.full_content = config.get("full_content", False)

--- a/mkdocs_blogging_plugin/plugin.py
+++ b/mkdocs_blogging_plugin/plugin.py
@@ -145,8 +145,6 @@ class BloggingPlugin(BasePlugin):
                     if self.use_root_dirs and f.parent.name in self.categories:
                         del self.categories[f.parent.name]
                     self.categories[name] = default_config
-            for k, v in self.categories.items():
-                print(k, v.__dict__)
         if isinstance(categories, list):
             for c in categories:
                 if isinstance(c, dict) and "name" in c:

--- a/mkdocs_blogging_plugin/plugin.py
+++ b/mkdocs_blogging_plugin/plugin.py
@@ -14,9 +14,9 @@ import yaml
 
 DIR_PATH = Path(os.path.dirname(os.path.realpath(__file__)))
 BLOG_PAGE_PATTERN = re.compile(
-    r"\{\{\s*blog_content\s+(([0-9]|[a-z]|[A-Z]|-|_)*)\s*\}\}", flags=re.IGNORECASE)
-TAG_PAGE_PATTERN = re.compile(
-    r"\{\{\s*tag_content\s*\}\}", flags=re.IGNORECASE)
+    r"\{\{\s*blog_content\s+(([0-9]|[a-z]|[A-Z]|-|_)*)\s*\}\}", flags=re.IGNORECASE
+)
+TAG_PAGE_PATTERN = re.compile(r"\{\{\s*tag_content\s*\}\}", flags=re.IGNORECASE)
 THEMES = ["card", "button"]
 with open(DIR_PATH / "templates" / "pagination.js") as file:
     SCRIPTS = "<script>" + file.read() + "</script>"
@@ -38,16 +38,23 @@ def get_config_scheme():
         ("template", config_options.Type(str, default=c.template)),
         ("theme", config_options.Type(dict, default=c.theme)),
         ("full_content", config_options.Type(bool, default=c.full_content)),
-
         # Global-only configurations
         ("meta_time_format", config_options.Type(str, default=None)),
         ("time_format", config_options.Type(str, default=None)),
         ("locale", config_options.Type(str, default=None)),
         ("features", config_options.Type(dict, default={})),
-        ("use_root_dirs", config_options.Type(bool, default=False)), #Use root_dirs with global parameters
-        ("config_filename", config_options.Type(str, default = "")), #use a config file to setup the plugin for each folder
-        ("exclude_index", config_options.Type(bool, default=False)), #Exclude index.md automatically from the blog listing pages
-
+        (
+            "use_root_dirs",
+            config_options.Type(bool, default=False),
+        ),  # Use root_dirs with global parameters
+        (
+            "config_filename",
+            config_options.Type(str, default=""),
+        ),  # use a config file to setup the plugin for each folder
+        (
+            "exclude_index",
+            config_options.Type(bool, default=False),
+        ),  # Exclude index.md automatically from the blog listing pages
         # Extra: categories (list of configs)
         ("categories", config_options.Type(list, default=[])),
     )
@@ -58,6 +65,7 @@ class BloggingPlugin(BasePlugin):
     Mkdocs plugin to add blogging functionality
     to mkdocs site.
     """
+
     def __init__(self):
         self.config_scheme = get_config_scheme()
         self.util = Util()
@@ -85,12 +93,7 @@ class BloggingPlugin(BasePlugin):
         self.categories: Dict[str, BloggingConfig] = {}
 
         # Blog pages
-        self.pages = {
-            "global": {
-                "html": None,
-                "pages": []
-            }
-        }
+        self.pages = {"global": {"html": None, "pages": []}}
 
         # Templates
         self.jinja_templates: Dict[str, Template] = {}
@@ -138,10 +141,12 @@ class BloggingPlugin(BasePlugin):
                     config = yaml.safe_load(stream)
                 this_categories = config.get("categories", None)
                 if this_categories:
-                    this_categories["dirs"] = this_categories.get("dirs", [f.parent.relative_to(docs_dir).as_posix()])
+                    this_categories["dirs"] = this_categories.get(
+                        "dirs", [f.parent.relative_to(docs_dir).as_posix()]
+                    )
                     default_config = BloggingConfig(this_categories)
-                    name = config['categories'].get('name', f.parent.name)
-                    #in case of the folder is registered with root, remove it
+                    name = config["categories"].get("name", f.parent.name)
+                    # in case of the folder is registered with root, remove it
                     if self.use_root_dirs and f.parent.name in self.categories:
                         del self.categories[f.parent.name]
                     self.categories[name] = default_config
@@ -150,9 +155,7 @@ class BloggingPlugin(BasePlugin):
                 if isinstance(c, dict) and "name" in c:
                     self.categories[c["name"]] = BloggingConfig(c)
         elif categories is not None:
-            logger.warning(
-                "[blogging-plugin] Config entry'categories' is not a list"
-            )
+            logger.warning("[blogging-plugin] Config entry'categories' is not a list")
 
         # Validate configs
         # Check if paging is on in any category
@@ -166,10 +169,16 @@ class BloggingPlugin(BasePlugin):
         # Abort with error with 'navigation.instant' feature on
         # because paging won't work with it.
         mkdocs_theme = global_config.get("theme")
-        if mkdocs_theme and "features" in mkdocs_theme and \
-                "navigation.instant" in mkdocs_theme["features"] and has_paging:
-            raise PluginError("[blogging-plugin] Feature 'navigation.instant' "
-                              "cannot be enabled with option 'paging' on.")
+        if (
+            mkdocs_theme
+            and "features" in mkdocs_theme
+            and "navigation.instant" in mkdocs_theme["features"]
+            and has_paging
+        ):
+            raise PluginError(
+                "[blogging-plugin] Feature 'navigation.instant' "
+                "cannot be enabled with option 'paging' on."
+            )
 
         # Walk through configs
         for _, config in self.categories.items():
@@ -201,18 +210,25 @@ class BloggingPlugin(BasePlugin):
         # Setup jinja templates
         search_paths = [DIR_PATH / "templates"]
         root_url = Path(global_config.get("config_file_path")).parents[0]
-        search_paths += [(root_url / c.template).parents[0]
-                         for _, c in self.categories.items() if c.template]
+        search_paths += [
+            (root_url / c.template).parents[0]
+            for _, c in self.categories.items()
+            if c.template
+        ]
 
         env = Environment(
-            loader=FileSystemLoader(search_paths),
-            autoescape=select_autoescape()
+            loader=FileSystemLoader(search_paths), autoescape=select_autoescape()
         )
 
         for name, config in self.categories.items():
             jinja_template = env.get_template(
-                (root_url / config.template).name if config.template else
-                (f"blog-{config.theme['name']}-theme.html" if config.theme else "blog.html")
+                (root_url / config.template).name
+                if config.template
+                else (
+                    f"blog-{config.theme['name']}-theme.html"
+                    if config.theme
+                    else "blog.html"
+                )
             )
             self.jinja_templates[name] = jinja_template
 
@@ -224,8 +240,9 @@ class BloggingPlugin(BasePlugin):
             index_path = self.features["tags"].get("index_page")
             if index_path:
                 index_path = Path(index_path)
-                self.tags_index_url = self.site_url + \
-                    (index_path.parents[0] / index_path.stem).as_posix()
+                self.tags_index_url = (
+                    self.site_url + (index_path.parents[0] / index_path.stem).as_posix()
+                )
                 # Adapt mkdocs's `use_directory_urls` setting.
                 # See https://www.mkdocs.org/user-guide/configuration/#use_directory_urls.
                 if global_config.get("use_directory_urls") == False:
@@ -258,7 +275,8 @@ class BloggingPlugin(BasePlugin):
         if "tags" in self.features and "tags" in page.meta:
             tags = page.meta["tags"]
             page = self.with_timestamp(
-                page, self.categories["global"].sort["by"] == "revision")
+                page, self.categories["global"].sort["by"] == "revision"
+            )
             if isinstance(tags, list):
                 for tag in tags:
                     if tag not in self.tags:
@@ -274,8 +292,13 @@ class BloggingPlugin(BasePlugin):
             # Insert tags into original page
             insert = self.features["tags"].get("insert")
             if insert:
-                tags_html = "\n" + self.tags_template.render(tags=page.meta["tags"],
-                                                             index_url=self.tags_index_url).strip() + "\n"
+                tags_html = (
+                    "\n"
+                    + self.tags_template.render(
+                        tags=page.meta["tags"], index_url=self.tags_index_url
+                    ).strip()
+                    + "\n"
+                )
                 if insert == "bottom":
                     markdown = markdown + "\n<br/>\n" + tags_html
                 else:
@@ -289,7 +312,9 @@ class BloggingPlugin(BasePlugin):
         been generated, the time when the meta from markdown file
         has already been added into the page instance.
         """
-        if ("exclude_from_blog" in page.meta and page.meta["exclude_from_blog"]) or (self.exclude_index and page.file.name == "index"):
+        if ("exclude_from_blog" in page.meta and page.meta["exclude_from_blog"]) or (
+            self.exclude_index and page.file.name == "index"
+        ):
             return
 
         file_path = Path(page.file.src_path)
@@ -299,7 +324,8 @@ class BloggingPlugin(BasePlugin):
             for dir in config.dirs:
                 if Path(dir) in file_path.parents:
                     self.pages[name]["pages"].append(
-                        self.with_timestamp(page, config.sort["by"] == "revision"))
+                        self.with_timestamp(page, config.sort["by"] == "revision")
+                    )
                     break
 
     def on_post_page(self, output, page, config):
@@ -326,15 +352,20 @@ class BloggingPlugin(BasePlugin):
         if "tags" in self.features and self.tags:
             if not self.tags_page_html:
                 tag_names = [tag for tag in self.tags]
-                sorted_entries = {tag: sorted(self.tags[tag],
-                                              key=lambda page: page.meta["git-timestamp"],
-                                              reverse=self.categories["global"].sort["from"] == "new"
-                                              )
-                                  for tag in self.tags}
+                sorted_entries = {
+                    tag: sorted(
+                        self.tags[tag],
+                        key=lambda page: page.meta["git-timestamp"],
+                        reverse=self.categories["global"].sort["from"] == "new",
+                    )
+                    for tag in self.tags
+                }
 
                 self.tags_page_html = self.tags_index_template.render(
-                    tags=tag_names, entries=sorted_entries,
-                    index_url=self.tags_index_url)
+                    tags=tag_names,
+                    entries=sorted_entries,
+                    index_url=self.tags_index_url,
+                )
 
             output = TAG_PAGE_PATTERN.sub(self.tags_page_html, output)
 
@@ -344,18 +375,23 @@ class BloggingPlugin(BasePlugin):
         config = self.categories[category]
         template = self.jinja_templates[category]
 
-        blog_pages = sorted(self.pages[category]["pages"],
-                            key=lambda page: page.meta["git-timestamp"],
-                            reverse=config.sort["from"] == "new"
-                            )
+        blog_pages = sorted(
+            self.pages[category]["pages"],
+            key=lambda page: page.meta["git-timestamp"],
+            reverse=config.sort["from"] == "new",
+        )
 
         theme_options = config.theme.get("options") if config.theme else []
 
         return template.render(
-            pages=blog_pages, page_size=config.size,
-            paging=config.paging, is_revision=config.sort["by"] == "revision",
-            show_total=config.show_total, theme_options=theme_options,
-            index_url=self.tags_index_url, show_tags="tags" in self.features,
+            pages=blog_pages,
+            page_size=config.size,
+            paging=config.paging,
+            is_revision=config.sort["by"] == "revision",
+            show_total=config.show_total,
+            theme_options=theme_options,
+            index_url=self.tags_index_url,
+            show_tags="tags" in self.features,
             mkdocs_context=self.mkdocs_template_context,
             full_content=config.full_content,
         )
@@ -365,15 +401,19 @@ class BloggingPlugin(BasePlugin):
         if self.meta_time_format:
             if "time" in page.meta:
                 timestamp = datetime.strptime(
-                    page.meta["time"], self.meta_time_format).timestamp()
+                    page.meta["time"], self.meta_time_format
+                ).timestamp()
             elif "date" in page.meta:
                 timestamp = datetime.strptime(
-                    page.meta["date"], self.meta_time_format).timestamp()
+                    page.meta["date"], self.meta_time_format
+                ).timestamp()
         if not timestamp:
             timestamp = self.util.get_git_commit_timestamp(
-                page.file.abs_src_path, is_first_commit=(not by_revision))
+                page.file.abs_src_path, is_first_commit=(not by_revision)
+            )
         page.meta["git-timestamp"] = timestamp
         page.meta["localized-time"] = self.util.get_localized_date(
-            timestamp, False, format=self.time_format, _locale=self.locale)
+            timestamp, False, format=self.time_format, _locale=self.locale
+        )
 
         return page

--- a/mkdocs_blogging_plugin/util.py
+++ b/mkdocs_blogging_plugin/util.py
@@ -43,6 +43,7 @@ from datetime import datetime
 
 logger = logging.getLogger("mkdocs.plugins")
 
+
 class Util:
     """Utility class.
 
@@ -62,12 +63,7 @@ class Util:
 
         return self.repo_cache[path]
 
-
-    def get_git_commit_timestamp(
-            self,
-            path: str,
-            is_first_commit: bool = False
-    ) -> int:
+    def get_git_commit_timestamp(self, path: str, is_first_commit: bool = False) -> int:
         """
         Get a list of commit dates in unix timestamp, starts with the most recent commit.
 
@@ -94,7 +90,7 @@ class Util:
                 commit_timestamp = git.log(
                     realpath, date="short", format="%at", diff_filter="A", follow=True
                 )
-                # A file can be created multiple times, through a file renamed. 
+                # A file can be created multiple times, through a file renamed.
                 # Commits are ordered with most recent commit first
                 # Get the oldest commit only
                 if commit_timestamp != "":
@@ -112,8 +108,7 @@ class Util:
         except GitCommandError as err:
             logger.warning(
                 "[blogging-plugin] Unable to read git logs of '%s'. Is git log readable?"
-                " Falling back to build date."
-                % path
+                " Falling back to build date." % path
             )
             commit_timestamp = time.time()
         except GitCommandNotFound as err:
@@ -127,14 +122,15 @@ class Util:
         if commit_timestamp == "":
             commit_timestamp = time.time()
             logger.warning(
-                "[blogging-plugin] '%s' has no git logs, using current timestamp"
-                % path
+                "[blogging-plugin] '%s' has no git logs, using current timestamp" % path
             )
 
         return int(commit_timestamp)
 
     @staticmethod
-    def get_localized_date(timestamp: float, day_only: bool, format: str=None, _locale: str=None) -> str:
+    def get_localized_date(
+        timestamp: float, day_only: bool, format: str = None, _locale: str = None
+    ) -> str:
         time = datetime.fromtimestamp(timestamp)
         if format:
             return datetime.strftime(time, format)

--- a/setup.py
+++ b/setup.py
@@ -13,9 +13,7 @@ setup(
     long_description=LONG_DESCRIPTION,
     long_description_content_type="text/markdown",
     keywords="mkdocs blog plugin",
-    project_urls={
-        "Source": "https://github.com/liang2kl/mkdocs-blogging-plugin"
-    },
+    project_urls={"Source": "https://github.com/liang2kl/mkdocs-blogging-plugin"},
     author="Liang Yesheang",
     author_email="liang2kl@outlook.com",
     include_package_data=True,
@@ -34,8 +32,6 @@ setup(
     install_requires=DEPENDENCIES,
     packages=find_packages(),
     entry_points={
-        "mkdocs.plugins": [
-            "blogging = mkdocs_blogging_plugin.plugin:BloggingPlugin"
-        ]
-    }
+        "mkdocs.plugins": ["blogging = mkdocs_blogging_plugin.plugin:BloggingPlugin"]
+    },
 )

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -7,17 +7,16 @@ from mkdocs_blogging_plugin.plugin import BloggingPlugin
 
 FILE_PATH = Path(os.path.realpath(__file__))
 
+
 class TestPluginConfig(unittest.TestCase):
     """Test basic config reading of categories."""
+
     @classmethod
     def setUpClass(cls):
         cls.config = {
             "dirs": "global_dir",
             "size": 4,
-            "sort": {
-                "from": "old",
-                "by": "revision"
-            },
+            "sort": {"from": "old", "by": "revision"},
             "paging": False,
             "show_total": False,
             "full_content": True,
@@ -28,23 +27,17 @@ class TestPluginConfig(unittest.TestCase):
                 "name": "c1",
                 "dirs": "c1_dir",
                 "size": 3,
-                "sort": {
-                    "from": "new",
-                    "by": "creation"
-                },
+                "sort": {"from": "new", "by": "creation"},
                 "paging": True,
                 "show_total": True,
                 "full_content": False,
             },
-            {
-                "name": "c2",
-                "dirs": "c2_dir"
-            }
+            {"name": "c2", "dirs": "c2_dir"},
         ]
 
         global_config = {
             "site_url": "https://example.com",
-            "config_file_path": FILE_PATH.as_posix()
+            "config_file_path": FILE_PATH.as_posix(),
         }
 
         cls.plugin = BloggingPlugin()
@@ -64,7 +57,9 @@ class TestPluginConfig(unittest.TestCase):
         for name, category in self.plugin.categories.items():
             if name == "global":
                 continue
-            category_dict = [c for c in self.config["categories"] if c["name"] == name][0]
+            category_dict = [c for c in self.config["categories"] if c["name"] == name][
+                0
+            ]
             assert category.dirs == category_dict.get("dirs", c.dirs)
             assert category.size == category_dict.get("size", c.size)
             assert category.sort == category_dict.get("sort", c.sort)
@@ -72,5 +67,5 @@ class TestPluginConfig(unittest.TestCase):
             assert category.show_total == category_dict.get("show_total", c.show_total)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tests/test_format.py
+++ b/tests/test_format.py
@@ -8,17 +8,18 @@ from mkdocs_blogging_plugin.plugin import BloggingPlugin
 
 FILE_PATH = Path(os.path.realpath(__file__))
 
+
 class TestPluginFormatting(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.config = {
             "meta_time_format": "%Y-%m-%d %H:%M:%S",
-            "time_format": "%Y/%m/%d %H:%M:%S"
+            "time_format": "%Y/%m/%d %H:%M:%S",
         }
 
         global_config = {
             "site_url": "https://example.com",
-            "config_file_path": FILE_PATH.as_posix()
+            "config_file_path": FILE_PATH.as_posix(),
         }
 
         cls.plugin = BloggingPlugin()
@@ -29,12 +30,10 @@ class TestPluginFormatting(unittest.TestCase):
         meta_date_str = "2022-05-03 11:09:00"
         page = SimpleNamespace(meta={"time": meta_date_str})
 
-        date = datetime.strptime(
-            meta_date_str, self.config["meta_time_format"])
-        
+        date = datetime.strptime(meta_date_str, self.config["meta_time_format"])
+
         page = self.plugin.with_timestamp(page, False)
 
-        expected_output = datetime.strftime(
-            date, self.config["time_format"])
+        expected_output = datetime.strftime(date, self.config["time_format"])
 
         assert page.meta["localized-time"] == expected_output

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -12,18 +12,15 @@ FILE_PATH = Path(os.path.realpath(__file__))
 class TestPluginFormatting(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        cls.config = {
-            "template": "test_data/template.html"
-        }
+        cls.config = {"template": "test_data/template.html"}
 
-        cls.config["categories"] = [{
-            "name": "c1",
-            "template": "test_data/template.html"
-        }]
+        cls.config["categories"] = [
+            {"name": "c1", "template": "test_data/template.html"}
+        ]
 
         global_config = {
             "site_url": "https://example.com",
-            "config_file_path": FILE_PATH.as_posix()
+            "config_file_path": FILE_PATH.as_posix(),
         }
 
         cls.plugin = BloggingPlugin()
@@ -31,5 +28,10 @@ class TestPluginFormatting(unittest.TestCase):
         cls.plugin.read_in_config(global_config)
 
     def test_template(self):
-        assert self.plugin.jinja_templates["global"].filename.split("/")[-1] == "template.html"
-        assert self.plugin.jinja_templates["c1"].filename.split("/")[-1] == "template.html"
+        assert (
+            self.plugin.jinja_templates["global"].filename.split("/")[-1]
+            == "template.html"
+        )
+        assert (
+            self.plugin.jinja_templates["c1"].filename.split("/")[-1] == "template.html"
+        )


### PR DESCRIPTION
Hello!
Your plugin is pretty great!
As I don't want to modify each time my `mkdocs.yml` I was thinking if I can use directly each roots folder as category. So, I created the new global settings `use_root_dirs` to allow this.

Also, I created a way to set each category independently, using a new global key `config_filename`. Using the value `.pages` allow to use the YAML file from the awesome pages plugin.
The configuration in it is the same of the mkdocs.yml, but you can set the dirs to only use the parent folder of the file

Finally, I think `index.md` must be excluded by default from the blog listing, so I made another global key `exclude_index`.

I updated the example to show each setting I made : https://obsidianpublisher.github.io/mkdocs-blogging-plugin-example/

Your code is pretty good! It was a pleasure to work on it.