### PR TITLE
change `zh-CN` to `zh_CN`

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -227,7 +227,7 @@ If it is not set, the plugin will take the build time as fallback.
 ```yaml title="article"
 plugins:
   - blogging:
-      locale: zh-CN
+      locale: zh_CN
 ```
 
 Otherwise, the plugin will use locale of the server, which might not be expected.


### PR DESCRIPTION
`zh-CN` will raise `ValueError` in Python 3.8/3.9/3.10/3.11 uwu