### PR TITLE
fix tuple int comparison error in version check

### DIFF
--- a/mkdocs_blogging_plugin/util.py
+++ b/mkdocs_blogging_plugin/util.py
@@ -142,7 +142,7 @@ class Util:
             return datetime.strftime(time, format)
         else:
             if not _locale:
-                if sys.version_info[0] < (3, 11):
+                if sys.version_info[:2] < (3, 11):
                     _locale = locale.getdefaultlocale()[0]
                 else:
                     _locale = locale.getlocale()[0]


### PR DESCRIPTION
Thanks for making this plugin!

My builds started failing with [the latest release](https://github.com/liang2kl/mkdocs-blogging-plugin/commit/3c24a66904ff641dbe50c93876ecfab6b182a702). Here's [an example](https://github.com/the-full-stack/website/actions/runs/5179777110/jobs/9333110908).

tl;dr: I'm getting errors on the new version info comparison wrapped around the locale setting, because the commit to resolve #50 introduced the expression `sys.version_info[0] < (3, 11)`, which produces `3 < (3, 11)` and then a `TypeError`. This code path is only triggered if `_locale` is not set in the call, so it may have been missed in testing.

The change in this PR should give the desired behavior. We check the tuple `sys.version_info[:2]` against `(3, 11)` instead. FWICT, this retains compatibility with Python <= 3.0 ([docs here](https://docs.python.org/3/library/sys.html#sys.version_info)). If Python >= 3.1 is okay, then `(sys.version_info.major, sys.version_info.minor)` in place of the direct indexing would be more clear.

Note that this commit also adds a newline at the end of file -- that's the default behavior of most editors. You can edit to remove it if you want.